### PR TITLE
Gamma correct, fix for stable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(custom_attribute)]
 #![allow(clippy::type_complexity, dead_code)]
 
 mod pass;

--- a/src/shaders/imgui.frag
+++ b/src/shaders/imgui.frag
@@ -6,5 +6,5 @@ layout (location = 0) out vec4 outColor;
 
 void main()
 {
-	outColor = inColor * texture(fontSampler, inUV);
+	outColor = pow(inColor * texture(fontSampler, inUV), vec4(2.2));
 }


### PR DESCRIPTION
The custom_attribute feature wasn't used but it broke rust stable.
Also gamma corrected in shader.

![](https://i.imgur.com/FcuAXuD.png)