### PR TITLE
Update to amethyst 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amethyst-imgui"
-version = "0.6.1"
+version = "0.7.0"
 description = "imgui library for amethyst"
 license = "CC0-1.0"
 authors = ["Awpteamoose <cargo@awpteamoose.my.to>", "Walter Pearce <jaynus@gmail.com>"]
@@ -16,7 +16,7 @@ docking = []
 [dependencies]
 imgui = { version = "0.2" }
 imgui-winit-support = { version = "0.2" }
-amethyst = { version = "0.14" }
+amethyst = { version = "0.15" }
 
 # Development dependencies
 #amethyst = { path = "../amethyst", features = ["saveload", "vulkan", "gltf", "experimental-spirv-reflection", "shader-compiler", "tiles"] }


### PR DESCRIPTION
Amethyst recently published a [0.15 release](https://github.com/amethyst/amethyst/releases/tag/v0.15.0), which unfortunately breaks this crate in a few ways:

![image](https://user-images.githubusercontent.com/155693/78407834-8e4d0300-75ba-11ea-9c8b-1acbfb976769.png)

Thankfully, it's only because of a transitive crate mismatch which we can fix by updating from Amethyst 0.14 to 0.15. No other changes are necessary.

Since this is likely a breaking change, I thought it might be appropriate to bump this crate to `0.7.0` instead of `0.6.2`.
