### PR TITLE
Updated to amethyst 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ docking = []
 [dependencies]
 imgui = { version = "0.2" }
 imgui-winit-support = { version = "0.2" }
-amethyst = { version = "0.14" }
+amethyst = { version = "0.15" }
 
 # Development dependencies
 #amethyst = { path = "../amethyst", features = ["saveload", "vulkan", "gltf", "experimental-spirv-reflection", "shader-compiler", "tiles"] }


### PR DESCRIPTION
Update amethyst version to 0.15 in Cargo.toml. No additional change is required to support this version.