### PR TITLE
Fix color representation for texture in example

### DIFF
--- a/examples/demo_custom_texture.rs
+++ b/examples/demo_custom_texture.rs
@@ -45,6 +45,7 @@ impl<'a, 'b> SystemDesc<'a, 'b, DemoSystem> for DemoSystemDesc {
 		let texture_builder = load_from_image(
 			image_reader,
 			image::ImageTextureConfig {
+				repr: image::Repr::Unorm,
 				generate_mips: true,
 				..Default::default()
 			},


### PR DESCRIPTION
I'm a bit over my head here but it seems like dear imgui expects colours to come in linear rgb space, so when we need to load textures we need to override the deafault `Repr` which is set to `Srgb`.

Does this mean if I want to use a texture in rendy and in dear imgui I need to load it twice? Once with `Srgb` for rendy and once with `Unorm` for dear imgui. I think this memory inefficient but computationally fast, so it's probably the right choice for now. However it does seem like there are some open discussions and even a PR for allowing dear imgui to work directly with srgb, if that gets resolved then there might be a away to use a single texture handle for both rendy and dear imgui.

Before:

<img width="955" alt="Screen Shot 2020-06-05 at 3 21 24 pm" src="https://user-images.githubusercontent.com/5869437/83965581-e81cc280-a8b4-11ea-8ced-56289ca2087e.png">

After:

<img width="966" alt="Screen Shot 2020-06-07 at 11 45 05 am" src="https://user-images.githubusercontent.com/5869437/83965587-f4a11b00-a8b4-11ea-8aa8-c5f28a25ed25.png">

